### PR TITLE
Change chrome page from browser.xul to browser.xhtml

### DIFF
--- a/src/add.rs
+++ b/src/add.rs
@@ -182,7 +182,7 @@ fn generic_style<T: BufRead>(
     // Add new style
     let name = read_name(input);
     let domain = if path.ends_with("userChrome.css") {
-        Some(String::from("url(chrome://browser/content/browser.xul)"))
+        Some(String::from("url(chrome://browser/content/browser.xhtml)"))
     } else {
         read_domain(input)
     };


### PR DESCRIPTION
Firefox 69 changes the address of the internal page, breaking existing setups. This updates to use the new URL.